### PR TITLE
Fix bug that shows duplicate recs when switching pages back and forth

### DIFF
--- a/client/redux/reducers/recsReducer.js
+++ b/client/redux/reducers/recsReducer.js
@@ -3,7 +3,7 @@ import initialState from './initialState';
 export default function recsReducer(state = initialState.recs, action) {
   switch (action.type) {
     case 'DISPLAY_RECS':
-      return [...state, ...action.recs];
+      return [...action.recs];
 
     default:
       return state;


### PR DESCRIPTION
### Summary

<!--- Provide a general summary of your changes in the Title above -->

Fix bug that shows duplicate recs when switching pages back and forth
##### Description

<!--- Describe your changes in detail -->

Update recsReducer to remove appending to state when returning current recommendations
##### Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
##### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Change required to fix bug
##### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated Testing
- [ ] Documentation
##### Testing Details

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

<!--- If there are none to be shared, report 'Travis CI - Build Passing'  -->

Tested locally
##### Screenshots (if appropriate)

<!--- Report 'N/A' if none --->

N/A
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
